### PR TITLE
Fix compilation failure due to implicit narrowing conversion

### DIFF
--- a/include/bno055_usb_stick/match_conditions.hpp
+++ b/include/bno055_usb_stick/match_conditions.hpp
@@ -15,8 +15,13 @@ struct ResponseCondition {
   std::pair< Iterator, bool > operator()(const Iterator begin, const Iterator end) {
     typedef typename Iterator::value_type Value;
     typedef std::pair< Iterator, bool > Result;
-    static const boost::array< Value, 1 > prefix = {0xaa};
-    static const boost::array< Value, 2 > suffix = {0x0d, 0x0a};
+    static const boost::array< Value, 1 > prefix = {
+        static_cast<Value>(0xaa)
+    };
+    static const boost::array< Value, 2 > suffix = {
+        static_cast<Value>(0x0d),
+        static_cast<Value>(0x0a)
+    };
 
     // find a prefix of response
     const Iterator response_begin(std::search(begin, end, prefix.begin(), prefix.end()));
@@ -66,9 +71,18 @@ struct DataCondition {
   std::pair< Iterator, bool > operator()(Iterator begin, Iterator end) {
     typedef typename Iterator::value_type Value;
     typedef std::pair< Iterator, bool > Result;
-    static const boost::array< Value, 5 > header = {0xaa, 0x38, 0x01, 0x00, 0x86};
+    static const boost::array< Value, 5 > header = {
+        static_cast<Value>(0xaa),
+        static_cast<Value>(0x38),
+        static_cast<Value>(0x01),
+        static_cast<Value>(0x00),
+        static_cast<Value>(0x86)
+    };
     static const std::size_t data_length(header[1]);
-    static const boost::array< Value, 2 > suffix = {0x0d, 0x0a};
+    static const boost::array< Value, 2 > suffix = {
+        static_cast<Value>(0x0d),
+        static_cast<Value>(0x0a)
+    };
 
     // find a header of data
     const Iterator data_begin(std::search(begin, end, header.begin(), header.end()));


### PR DESCRIPTION
This error is observed under Ubuntu 18.04.1 with gcc
7.3.0-27ubuntu1~18.04, where the default C++ standard is C++14. In C++11
and later, list initializers prohibit narrowing conversions and result
in compilation error.